### PR TITLE
Added vrf auto-provisioning for lxc network devices

### DIFF
--- a/src/lxc/confile_utils.c
+++ b/src/lxc/confile_utils.c
@@ -308,6 +308,10 @@ void lxc_log_configured_netdevs(const struct lxc_conf *conf)
 				TRACE("hwaddr: %s", netdev->hwaddr);
 			if (netdev->mtu)
 				TRACE("mtu: %s", netdev->mtu);
+			if (netdev->vrf)
+				TRACE("vrf: %s", netdev->vrf);
+			if (netdev->table_id)
+				TRACE("vrf table id: %s", netdev->table_id);
 			if (netdev->upscript)
 				TRACE("upscript: %s", netdev->upscript);
 			if (netdev->downscript)
@@ -356,6 +360,8 @@ static void lxc_free_netdev(struct lxc_netdev *netdev)
 	free(netdev->downscript);
 	free(netdev->hwaddr);
 	free(netdev->mtu);
+	free(netdev->vrf);
+	free(netdev->table_id);
 
 	free(netdev->ipv4_gateway);
 	lxc_list_for_each_safe(cur, &netdev->ipv4, next) {

--- a/src/lxc/network.h
+++ b/src/lxc/network.h
@@ -165,6 +165,8 @@ struct lxc_netdev {
 	char name[IFNAMSIZ];
 	char *hwaddr;
 	char *mtu;
+	char *vrf;
+	char *table_id;
 	union netdev_p priv;
 	struct lxc_list ipv4;
 	struct lxc_list ipv6;
@@ -202,6 +204,8 @@ extern int lxc_netdev_down(const char *name);
 
 /* Change the mtu size for the specified device. */
 extern int lxc_netdev_set_mtu(const char *name, int mtu);
+
+extern int lxc_netdev_set_vrf(const char *name, const char *vrf, const char *table_id);
 
 /* Create a virtual network devices. */
 extern int lxc_veth_create(const char *name1, const char *name2);


### PR DESCRIPTION
For example, if you want to create vrf and set interface to this vrf you can just add these lines to config file.

lxc.net.0.vrf = RED
lxc.net.0.table_id = 666
